### PR TITLE
WC Knockout Round support

### DIFF
--- a/backend/src/leagues/leagues.service.ts
+++ b/backend/src/leagues/leagues.service.ts
@@ -134,4 +134,12 @@ export class LeaguesService {
     const settings = await this.getLatestLeagueSettingsByLeague(leagueId);
     return this.getPositionsForLeagueSettings(settings.leagueSettingsId);
   }
+
+  async getPositionForLeagueSettings(leagueSettingsId: string, position: string): Promise<ILeagueSettingsPosition> {
+    const leagueSettingsPosition = (await this.getPositionsForLeagueSettings(leagueSettingsId)).find((lSP) => lSP.position === position);
+    if (!leagueSettingsPosition) {
+      throw new NotFoundException(`Position: ${position} does not exist for league settings id: ${leagueSettingsId}`);
+    }
+    return leagueSettingsPosition;
+  }
 }

--- a/backend/src/teams/teams.service.spec.ts
+++ b/backend/src/teams/teams.service.spec.ts
@@ -53,7 +53,7 @@ describe('TeamsService', () => {
       updateAuditStatus: jest.fn(),
     } as any;
 
-    const mockLeaguesService = { findOne: jest.fn(), getLatestLeagueSettingsByLeague: jest.fn(), getPositionsForLeagueSettings: jest.fn() } as any;
+    const mockLeaguesService = { findOne: jest.fn(), getLatestLeagueSettingsByLeague: jest.fn() } as any;
     const mockPlayerStatsService = { getPlayerProjections: jest.fn() } as any;
     const mockEventsService = { findOneEventGroup: jest.fn() } as any;
     const mockRegistry = { get: jest.fn().mockReturnValue({ getExcludedPlayerIds: jest.fn().mockResolvedValue([]), getNumberOfCases: jest.fn().mockReturnValue(10), normalizePlayerName: jest.fn(), usesSharedPlayerPool: jest.fn() }) };
@@ -231,7 +231,6 @@ describe('TeamsService — golf shared pool exclusion', () => {
     leaguesService = {
       findOne: jest.fn(),
       getLatestLeagueSettingsByLeague: jest.fn(),
-      getPositionsForLeagueSettings: jest.fn(),
       getPositionForLeagueSettings: jest.fn(),
     } as any;
 
@@ -281,7 +280,6 @@ describe('TeamsService — golf shared pool exclusion', () => {
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);
       entryRepo.findLatestEntryForTeamPosition.mockResolvedValue(null);
       entryRepo.createEntry.mockResolvedValue(mockTeamEntry('GOLF_PLAYER_1'));
-      leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
       leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[0]);
       entryRepo.insertAuditSnapshots.mockResolvedValue(undefined as any);
 
@@ -307,7 +305,6 @@ describe('TeamsService — golf shared pool exclusion', () => {
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);
       entryRepo.findLatestEntryForTeamPosition.mockResolvedValue(null);
       entryRepo.createEntry.mockResolvedValue(mockTeamEntry('GOLF_PLAYER_1'));
-      leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
       leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[0]);
       entryRepo.insertAuditSnapshots.mockResolvedValue(undefined as any);
 
@@ -364,7 +361,6 @@ describe('TeamsService — golf shared pool exclusion', () => {
       mockGolfStrategy.getExcludedPlayerIds.mockResolvedValue(['player-5']);
       leaguesService.findOne.mockResolvedValue({ leagueId: 'golf-league-1', name: 'Golf League', sportLeague: SportLeague.GOLF } as any);
       leaguesService.getLatestLeagueSettingsByLeague.mockResolvedValue({ leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' } as any);
-      leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
       leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[1]);
       eventsService.findOneEventGroup.mockResolvedValue({ eventGroupId: 'eg-1', name: 'The Masters', sportLeague: SportLeague.GOLF } as any);
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);
@@ -419,7 +415,6 @@ describe('TeamsService — golf shared pool exclusion', () => {
       });
       leaguesService.findOne.mockResolvedValue({ leagueId: 'golf-league-1', name: 'Golf League', sportLeague: SportLeague.GOLF } as any);
       leaguesService.getLatestLeagueSettingsByLeague.mockResolvedValue({ leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' } as any);
-      leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
       leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[1]);
       eventsService.findOneEventGroup.mockResolvedValue({ eventGroupId: 'eg-1', name: 'The Masters', sportLeague: SportLeague.GOLF } as any);
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);

--- a/backend/src/teams/teams.service.spec.ts
+++ b/backend/src/teams/teams.service.spec.ts
@@ -232,6 +232,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
       findOne: jest.fn(),
       getLatestLeagueSettingsByLeague: jest.fn(),
       getPositionsForLeagueSettings: jest.fn(),
+      getPositionForLeagueSettings: jest.fn(),
     } as any;
 
     playerStatsService = {
@@ -281,6 +282,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
       entryRepo.findLatestEntryForTeamPosition.mockResolvedValue(null);
       entryRepo.createEntry.mockResolvedValue(mockTeamEntry('GOLF_PLAYER_1'));
       leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
+      leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[0]);
       entryRepo.insertAuditSnapshots.mockResolvedValue(undefined as any);
 
       const leagueSettings = { leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' };
@@ -306,6 +308,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
       entryRepo.findLatestEntryForTeamPosition.mockResolvedValue(null);
       entryRepo.createEntry.mockResolvedValue(mockTeamEntry('GOLF_PLAYER_1'));
       leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
+      leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[0]);
       entryRepo.insertAuditSnapshots.mockResolvedValue(undefined as any);
 
       const leagueSettings = { leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' };
@@ -362,6 +365,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
       leaguesService.findOne.mockResolvedValue({ leagueId: 'golf-league-1', name: 'Golf League', sportLeague: SportLeague.GOLF } as any);
       leaguesService.getLatestLeagueSettingsByLeague.mockResolvedValue({ leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' } as any);
       leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
+      leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[1]);
       eventsService.findOneEventGroup.mockResolvedValue({ eventGroupId: 'eg-1', name: 'The Masters', sportLeague: SportLeague.GOLF } as any);
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);
       playerStatsService.getTeamAndOpponentForPlayer = jest.fn().mockReturnValue({ team: 'GOLF', opponent: '' });
@@ -416,6 +420,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
       leaguesService.findOne.mockResolvedValue({ leagueId: 'golf-league-1', name: 'Golf League', sportLeague: SportLeague.GOLF } as any);
       leaguesService.getLatestLeagueSettingsByLeague.mockResolvedValue({ leagueSettingsId: 'ls-1', leagueId: 'golf-league-1', scoringType: 'PPR' } as any);
       leaguesService.getPositionsForLeagueSettings.mockResolvedValue(GOLF_POSITIONS);
+      leaguesService.getPositionForLeagueSettings.mockResolvedValue(GOLF_POSITIONS[1]);
       eventsService.findOneEventGroup.mockResolvedValue({ eventGroupId: 'eg-1', name: 'The Masters', sportLeague: SportLeague.GOLF } as any);
       playerStatsService.getPlayerProjections.mockResolvedValue(projections);
       entryRepo.insertAuditSnapshots.mockResolvedValue(undefined as any);

--- a/backend/src/teams/teams.service.ts
+++ b/backend/src/teams/teams.service.ts
@@ -1,7 +1,7 @@
+import { SportLeague } from '@/common/types/sport-league.type';
 import { shuffle } from '@/common/util';
 import { EventsService } from '@/events/events.service';
 import { ILeagueSettings } from '@/leagues/entities/league-settings.entity';
-import { SportLeague } from '@/common/types/sport-league.type';
 import { LeaguesService } from '@/leagues/leagues.service';
 import {
   IPlayerProjection,
@@ -9,7 +9,6 @@ import {
   PlayerProjectionResponse,
 } from '@/player-stats/entities/player-stats.entity';
 import { PlayerStatsService } from '@/player-stats/player-stats.service';
-import { TeamsGameStrategyRegistry } from './strategies/teams-game-strategy.registry';
 import { ITeamPlayer, TeamPlayer } from '@/teams/entities/team-player.entity';
 import { ITeamStatus } from '@/teams/entities/team-status.entity';
 import { TeamsEntryRepository } from '@/teams/teams-entry.repository';
@@ -30,6 +29,7 @@ import {
   TeamEntryOfferStatus,
 } from './entities/team-entry.entity';
 import { CreateTeamDto, ITeam, Team, UpdateTeamDto } from './entities/team.entity';
+import { TeamsGameStrategyRegistry } from './strategies/teams-game-strategy.registry';
 
 @Injectable()
 export class TeamsService {
@@ -347,7 +347,7 @@ export class TeamsService {
 
     const team: ITeam = await this.findOne(teamEntry.teamId);
     const league = await this.leaguesService.findOne(team.leagueId);
-    const strategy = this.teamsGameRegistry.get(league.sportLeague);
+
     const projections = await this.playerStatsService.getPlayerProjections(
       teamEntry.position,
       team.seasonYear,
@@ -363,7 +363,7 @@ export class TeamsService {
     let playerIdsInBoxes = teamEntryAudits.map((entry) => entry.playerId);
 
     const poolSize = (await this.leaguesService.getPositionForLeagueSettings(teamEntry.leagueSettingsId, teamEntry.position)).poolSize;
-    const poolProjections = await strategy.determinePlayerPool(projections, team, teamEntry.position, poolSize);
+    const poolProjections = await this.teamsGameRegistry.get(league.sportLeague).determinePlayerPool(projections, team, teamEntry.position, poolSize);
 
     let availableOffers = poolProjections.filter(
       (player) =>

--- a/backend/src/teams/teams.service.ts
+++ b/backend/src/teams/teams.service.ts
@@ -254,9 +254,7 @@ export class TeamsService {
     );
     let boxNumber = 1;
 
-    //TODO this seems like we could probably extract this logic to a "getPositionForLeagueSettings" method on LeaguesService
-    const poolSize = (await this.leaguesService.getPositionsForLeagueSettings(leagueSettings.leagueSettingsId))
-      .find((positionSettings) => positionSettings.position === position)?.poolSize!;
+    const poolSize = (await this.leaguesService.getPositionForLeagueSettings(leagueSettings.leagueSettingsId, position)).poolSize;
 
     let trimmedPlayers: IPlayerProjection[] = await this.teamsGameRegistry
       .get(sportLeague)
@@ -349,6 +347,7 @@ export class TeamsService {
 
     const team: ITeam = await this.findOne(teamEntry.teamId);
     const league = await this.leaguesService.findOne(team.leagueId);
+    const strategy = this.teamsGameRegistry.get(league.sportLeague);
     const projections = await this.playerStatsService.getPlayerProjections(
       teamEntry.position,
       team.seasonYear,
@@ -360,16 +359,16 @@ export class TeamsService {
     const previousOffers = await this.getOffers(teamEntry.teamId, teamEntry.position);
     const previousOfferPlayerIds = previousOffers.map((offer) => offer.playerId);
 
-    // For sports with shared player pools (e.g., GOLF), exclude players already selected for other positions
-    const excludedPlayerIds = await this.teamsGameRegistry.get(league.sportLeague).getExcludedPlayerIds(team, teamEntry.position);
-
     // Remove players in boxes, previously offered players, and already-selected players from the projections
     let playerIdsInBoxes = teamEntryAudits.map((entry) => entry.playerId);
-    let availableOffers = projections.filter(
+
+    const poolSize = (await this.leaguesService.getPositionForLeagueSettings(teamEntry.leagueSettingsId, teamEntry.position)).poolSize;
+    const poolProjections = await strategy.determinePlayerPool(projections, team, teamEntry.position, poolSize);
+
+    let availableOffers = poolProjections.filter(
       (player) =>
         !playerIdsInBoxes.includes(player.playerId) &&
-        !previousOfferPlayerIds.includes(player.playerId) &&
-        !excludedPlayerIds.includes(player.playerId),
+        !previousOfferPlayerIds.includes(player.playerId),
     );
 
     if (availableOffers.length === 0) {

--- a/backend/src/world-cup/strategies/world-cup-player-stats.strategy.ts
+++ b/backend/src/world-cup/strategies/world-cup-player-stats.strategy.ts
@@ -18,7 +18,7 @@ export class WorldCupPlayerStatsStrategy implements IPlayerStatsStrategy {
     const roundId = this.resolveWorldCupRoundId(events);
     const projections = await this.fifaService.getRoundProjections(roundId);
     return projections
-      .filter((p) => p.status !== 'transferred')
+      .filter((p) => p.status === 'playing')
       .filter((p) => p.position === position)
       .map((p) => ({
         playerId: `${p.id}`,
@@ -40,7 +40,6 @@ export class WorldCupPlayerStatsStrategy implements IPlayerStatsStrategy {
     const roundId = this.resolveWorldCupRoundId(events);
     const projections = await this.fifaService.getRoundProjections(roundId);
     return projections
-      .filter((p) => p.status !== 'transferred')
       .filter((p) => p.position === position)
       .map((p) => ({
         playerId: `${p.id}`,

--- a/backend/src/world-cup/strategies/world-cup-teams-game.strategy.spec.ts
+++ b/backend/src/world-cup/strategies/world-cup-teams-game.strategy.spec.ts
@@ -32,14 +32,14 @@ describe('WorldCupTeamsGameStrategy', () => {
       ];
       const team = { players: [] } as unknown as ITeam;
 
-      // poolSize matches quota sum (2 countries × 1 GK each)
-      const pool = await strategy.determinePlayerPool(projections, team, 'GK', 2);
+      // computed poolSize = 2 × 1 + ⌊2/2⌋ = 3 → 2 quota picks + 1 remainder
+      const pool = await strategy.determinePlayerPool(projections, team, 'GK', 3);
 
-      expect(pool).toHaveLength(2);
-      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'bra1']);
+      expect(pool).toHaveLength(3);
+      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'bra1']);
     });
 
-    it('only includes 2 DEF per country (quota)', async () => {
+    it('only includes 3 DEF per country (quota)', async () => {
       const projections = [
         makeProjection('arg1', 'DEF', 'ARG', 10),
         makeProjection('arg2', 'DEF', 'ARG', 9),
@@ -48,14 +48,14 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('bra2', 'DEF', 'BRA', 6),
       ];
 
-      // poolSize matches quota sum (2 countries × 2 DEF each)
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 4);
+      // computed poolSize = 2 × 3 + ⌊2/2⌋ = 7 → all 5 projections fit within quota
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 7);
 
-      expect(pool).toHaveLength(4);
-      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'bra1', 'bra2']);
+      expect(pool).toHaveLength(5);
+      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'arg3', 'bra1', 'bra2']);
     });
 
-    it('fills remaining slots with best unselected players up to poolSize', async () => {
+    it('fills remaining slots with best unselected players up to computed poolSize', async () => {
       const projections = [
         makeProjection('arg1', 'GK', 'ARG', 10),
         makeProjection('arg2', 'GK', 'ARG', 9),
@@ -65,16 +65,16 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('uru2', 'GK', 'URU', 10),
       ];
 
-      // 3 countries × 1 GK quota = 3, poolSize 5 → remainder fills 2 slot with best (uru2, arg2)
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 5);
+      // computed poolSize = 3 × 1 + ⌊3/2⌋ = 4 → 3 quota picks + 1 remainder (uru2)
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 4);
 
-      expect(pool).toHaveLength(5);
-      expect(pool).toEqual(['arg1', 'bra1', 'uru1', 'uru2', 'arg2'].map(id =>
+      expect(pool).toHaveLength(4);
+      expect(pool).toEqual(['arg1', 'bra1', 'uru1', 'uru2'].map(id =>
         expect.objectContaining({ playerId: id }),
       ));
     });
 
-    it('does not add more players than poolSize from remainder', async () => {
+    it('fills remainder up to computed poolSize without overflow', async () => {
       const projections = [
         makeProjection('arg1', 'GK', 'ARG', 10),
         makeProjection('arg2', 'GK', 'ARG', 9),
@@ -82,11 +82,11 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('uru1', 'GK', 'URU', 6),
       ];
 
-      // 3 countries × 1 GK quota = 3, poolSize 3 → no remainder fill
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 3);
+      // computed poolSize = 3 × 1 + ⌊3/2⌋ = 4 → 3 quota picks + 1 remainder (arg2)
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 4);
 
-      expect(pool).toHaveLength(3);
-      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'bra1', 'uru1']);
+      expect(pool).toHaveLength(4);
+      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'bra1', 'uru1']);
     });
 
     it('does not duplicate players between quota and remainder', async () => {

--- a/backend/src/world-cup/strategies/world-cup-teams-game.strategy.ts
+++ b/backend/src/world-cup/strategies/world-cup-teams-game.strategy.ts
@@ -6,8 +6,8 @@ import { ITeamsGameStrategy } from '@/teams/strategies/teams-game-strategy.inter
 
 const PER_COUNTRY_QUOTA: Record<string, number> = {
   GK: 1,
-  DEF: 2,
-  MID: 2,
+  DEF: 3,
+  MID: 3,
   FWD: 2,
 };
 
@@ -21,11 +21,14 @@ export class WorldCupTeamsGameStrategy implements ITeamsGameStrategy {
     return Promise.resolve([]);
   }
 
+  /*
+    For WC, we want to override the pool size so that it is dynamic based on the number of teams remaining
+   */
   async determinePlayerPool(
     projections: IPlayerProjection[],
     team: ITeam,
     position: string,
-    poolSize: number,
+    _poolSize: number,
   ): Promise<IPlayerProjection[]> {
     const excluded = await this.getExcludedPlayerIds(team, position);
     const eligible = projections.filter(p => !excluded.includes(p.playerId));
@@ -47,6 +50,8 @@ export class WorldCupTeamsGameStrategy implements ITeamsGameStrategy {
         });
     }
 
+    // Pool size is the per-position quota times the number of countries, plus the next top countries/2 players
+    const poolSize: number = Math.floor(countries.size * quota + (countries.size / 2));
     pool.push(...sortedPlayerProjections
       .filter(p => !takenIds.has(p.playerId))
       .slice(0, poolSize - pool.length));


### PR DESCRIPTION
Resolves #22 
Adjusts logic for WC player pools (1/3/3/2 per country, plus #countries/2 remaining)
Change offer calculation to use same player pool logic as case generation
