### PR TITLE
Resolve #26 - support for world cup quarterfinals

### DIFF
--- a/backend/src/golf/strategies/golf-teams-game.strategy.ts
+++ b/backend/src/golf/strategies/golf-teams-game.strategy.ts
@@ -24,6 +24,7 @@ export class GolfTeamsGameStrategy implements ITeamsGameStrategy {
     team: ITeam,
     position: string,
     poolSize: number,
+    _eventGroup?: EventGroup,
   ): Promise<IPlayerProjection[]> {
     const excluded = await this.getExcludedPlayerIds(team, position);
     return projections

--- a/backend/src/nfl/strategies/nfl-teams-game.strategy.ts
+++ b/backend/src/nfl/strategies/nfl-teams-game.strategy.ts
@@ -19,6 +19,7 @@ export class NflTeamsGameStrategy implements ITeamsGameStrategy {
     team: ITeam,
     position: string,
     poolSize: number,
+    _eventGroup?: EventGroup,
   ): Promise<IPlayerProjection[]> {
     const excluded = await this.getExcludedPlayerIds(team, position);
     return projections

--- a/backend/src/teams/strategies/teams-game-strategy.interface.ts
+++ b/backend/src/teams/strategies/teams-game-strategy.interface.ts
@@ -38,13 +38,15 @@ export interface ITeamsGameStrategy {
    * returns the subset that should appear in the Deal or No Deal case
    * selection board. The default implementation filters out excluded
    * players and trims to the pool size; sports with specific constraints
-   * (e.g. World Cup per-country quotas) may override this with custom
-   * selection logic.
+   * (e.g. World Cup per-country quotas, event-stage-dependent pool sizing)
+   * may override this with custom selection logic.
    *
    * @param projections All eligible player projections for the position.
    * @param team        The team being drafted for.
    * @param position    The roster slot position (e.g. "QB", "GK", "DEF").
    * @param poolSize    Maximum number of players to return.
+   * @param eventGroup  Optional event group context for tournament-stage-aware
+   *                    pool sizing (e.g. World Cup quarterfinals).
    * @returns The player pool for the case board.
    */
   determinePlayerPool(
@@ -52,6 +54,7 @@ export interface ITeamsGameStrategy {
     team: ITeam,
     position: string,
     poolSize: number,
+    eventGroup?: EventGroup,
   ): Promise<IPlayerProjection[]>;
 
   /**

--- a/backend/src/teams/teams.service.spec.ts
+++ b/backend/src/teams/teams.service.spec.ts
@@ -7,6 +7,7 @@ import { ITeam, Team, CreateTeamDto, UpdateTeamDto } from './entities/team.entit
 import { TeamsRepository } from '@/teams/teams.repository';
 import { LeaguesService } from '@/leagues/leagues.service';
 import { PlayerStatsService } from '@/player-stats/player-stats.service';
+import { EventGroup } from '@/events/entities/event-group.entity';
 import { EventsService } from '@/events/events.service';
 import { IPlayerProjection } from '@/player-stats/entities/player-stats.entity';
 import { TeamsGameStrategyRegistry } from '@/teams/strategies/teams-game-strategy.registry';
@@ -188,7 +189,7 @@ describe('TeamsService — golf shared pool exclusion', () => {
   /** Shared mock strategy for TeamsGameStrategyRegistry. */
   const mockGolfStrategy = {
     getExcludedPlayerIds: jest.fn(),
-    determinePlayerPool: jest.fn(async (projections: IPlayerProjection[], team: ITeam, position: string, poolSize: number) => {
+    determinePlayerPool: jest.fn(async (projections: IPlayerProjection[], team: ITeam, position: string, poolSize: number, _eventGroup?: EventGroup) => {
       const excluded = await mockGolfStrategy.getExcludedPlayerIds(team, position);
       return projections
         .filter(p => !excluded.includes(p.playerId))

--- a/backend/src/teams/teams.service.ts
+++ b/backend/src/teams/teams.service.ts
@@ -1,5 +1,6 @@
 import { SportLeague } from '@/common/types/sport-league.type';
 import { shuffle } from '@/common/util';
+import { EventGroup } from '@/events/entities/event-group.entity';
 import { EventsService } from '@/events/events.service';
 import { ILeagueSettings } from '@/leagues/entities/league-settings.entity';
 import { LeaguesService } from '@/leagues/leagues.service';
@@ -210,7 +211,7 @@ export class TeamsService {
   async resetCases(teamId: string, position: string) {
     let teamEntry = await this.getTeamEntry(teamId, position);
     //We do not need a new entry per reset count. We should be updating, and there should generally only be one entry per team/position
-    //The only thing that doesn't have a reset_number is team_entry_offer, but you shouldn't be able to reset after getting an offer anyways
+    //The only thing that doesn't have a reset_number is team_entry_offer, but you shouldn't be able to reset after getting an offer anyway
     let updatedTeamEntry = await this.teamsEntryRepository.updateEntry(teamEntry.teamEntryId, {
       status: 'pending',
       resetCount: teamEntry.resetCount + 1,
@@ -230,6 +231,7 @@ export class TeamsService {
       leagueSettings,
       league.sportLeague,
       this.teamsGameRegistry.get(league.sportLeague).getNumberOfCases(eventGroup),
+      eventGroup,
     );
   }
 
@@ -239,6 +241,7 @@ export class TeamsService {
     leagueSettings: ILeagueSettings,
     sportLeague: SportLeague,
     numberOfCases: number = 10,
+    eventGroup?: EventGroup,
   ) {
     let playerProjections: PlayerProjectionResponse =
       await this.playerStatsService.getPlayerProjections(
@@ -258,7 +261,7 @@ export class TeamsService {
 
     let trimmedPlayers: IPlayerProjection[] = await this.teamsGameRegistry
       .get(sportLeague)
-      .determinePlayerPool(playerProjections, team, position, poolSize);
+      .determinePlayerPool(playerProjections, team, position, poolSize, eventGroup);
 
     let cases: Array<Omit<ITeamEntryAudit, 'auditId'>> = shuffle(trimmedPlayers)
       .slice(0, numberOfCases)
@@ -309,14 +312,14 @@ export class TeamsService {
     const audits = await this.teamsEntryRepository.findCurrentAuditsForEntry(entry.teamEntryId);
     if (audits.length === 0) {
       // Generate cases - this also handles shared pool exclusion for GOLF
+      const eventGroup = await this.eventsService.findOneEventGroup(team.eventGroupId);
       await this.generateCasesForPosition(
         team,
         position,
         leagueSettings,
         league.sportLeague,
-        this.teamsGameRegistry.get(league.sportLeague).getNumberOfCases(
-          await this.eventsService.findOneEventGroup(team.eventGroupId),
-        ),
+        this.teamsGameRegistry.get(league.sportLeague).getNumberOfCases(eventGroup),
+        eventGroup,
       );
     }
 
@@ -363,7 +366,8 @@ export class TeamsService {
     let playerIdsInBoxes = teamEntryAudits.map((entry) => entry.playerId);
 
     const poolSize = (await this.leaguesService.getPositionForLeagueSettings(teamEntry.leagueSettingsId, teamEntry.position)).poolSize;
-    const poolProjections = await this.teamsGameRegistry.get(league.sportLeague).determinePlayerPool(projections, team, teamEntry.position, poolSize);
+    const eventGroup = await this.eventsService.findOneEventGroup(team.eventGroupId);
+    const poolProjections = await this.teamsGameRegistry.get(league.sportLeague).determinePlayerPool(projections, team, teamEntry.position, poolSize, eventGroup);
 
     let availableOffers = poolProjections.filter(
       (player) =>

--- a/backend/src/world-cup/strategies/world-cup-event-sync.strategy.ts
+++ b/backend/src/world-cup/strategies/world-cup-event-sync.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { FifaService } from '@/external-providers/fifa/fifa.service';
 import { IEventSyncStrategy, EventSyncGroup } from '@/events/strategies/event-sync-strategy.interface';
 
-const WORLD_CUP_STAGE_NAMES: Record<string, string> = {
+export const WORLD_CUP_STAGE_NAMES: Record<string, string> = {
   R32: 'Round of 32',
   R16: 'Round of 16',
   QF: 'Quarter-finals',

--- a/backend/src/world-cup/strategies/world-cup-teams-game.strategy.spec.ts
+++ b/backend/src/world-cup/strategies/world-cup-teams-game.strategy.spec.ts
@@ -1,3 +1,4 @@
+import { EventGroup } from '@/events/entities/event-group.entity';
 import { WorldCupTeamsGameStrategy } from './world-cup-teams-game.strategy';
 import { ITeam } from '@/teams/entities/team.entity';
 import { IPlayerProjection } from '@/player-stats/entities/player-stats.entity';
@@ -23,6 +24,25 @@ describe('WorldCupTeamsGameStrategy', () => {
   });
 
   describe('determinePlayerPool', () => {
+    const nonQfEventGroup = { name: 'World Cup Group Stage – Matchday 1' } as EventGroup;
+
+    it('adds countries/2 extra GKs for quarterfinals', async () => {
+      const projections = [
+        makeProjection('arg1', 'GK', 'ARG', 10),
+        makeProjection('arg2', 'GK', 'ARG', 8),
+        makeProjection('bra1', 'GK', 'BRA', 9),
+        makeProjection('bra2', 'GK', 'BRA', 7),
+      ];
+      const team = { players: [], eventGroupId: 'eg-1' } as unknown as ITeam;
+      const eventGroup = { name: 'World Cup Knockout Stage – Quarter-finals' } as EventGroup;
+
+      // computed poolSize = 2 × 1 + ⌊2/2⌋ = 3 (extra factor applies for QF)
+      const pool = await strategy.determinePlayerPool(projections, team, 'GK', 3, eventGroup);
+
+      expect(pool).toHaveLength(3);
+      expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'bra1']);
+    });
+
     it('only includes 1 GK per country (quota)', async () => {
       const projections = [
         makeProjection('arg1', 'GK', 'ARG', 10),
@@ -33,7 +53,7 @@ describe('WorldCupTeamsGameStrategy', () => {
       const team = { players: [] } as unknown as ITeam;
 
       // computed poolSize = 2 × 1 = 2 quota picks
-      const pool = await strategy.determinePlayerPool(projections, team, 'GK', 2);
+      const pool = await strategy.determinePlayerPool(projections, team, 'GK', 2, nonQfEventGroup);
 
       expect(pool).toHaveLength(2);
       expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'bra1']);
@@ -49,7 +69,7 @@ describe('WorldCupTeamsGameStrategy', () => {
       ];
 
       // computed poolSize = 2 × 3 + ⌊2/2⌋ = 7 → all 5 projections fit within quota
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 7);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 7, nonQfEventGroup);
 
       expect(pool).toHaveLength(5);
       expect(pool.map(p => p.playerId).sort()).toEqual(['arg1', 'arg2', 'arg3', 'bra1', 'bra2']);
@@ -69,7 +89,7 @@ describe('WorldCupTeamsGameStrategy', () => {
       ];
 
       // computed poolSize = 3 × 2 + ⌊3/2⌋ = 7 → 6 quota picks + 1 remainder (uru2)
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'FWD', 1);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'FWD', 1, nonQfEventGroup);
 
       expect(pool).toHaveLength(7);
       expect(pool).toEqual(['arg1', 'arg2', 'bra1', 'bra2', 'uru1', 'uru2', 'uru3'].map(id =>
@@ -86,7 +106,7 @@ describe('WorldCupTeamsGameStrategy', () => {
       ];
 
       // computed poolSize = 3 × 1 = 3 → 3 quota picks
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 1);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 1, nonQfEventGroup);
 
       expect(pool).toHaveLength(3);
       expect(pool.map(p => p.playerId).sort()).toEqual(['arg2', 'bra1', 'uru1']);
@@ -100,7 +120,7 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('bra2', 'GK', 'BRA', 7),
       ];
 
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 10);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 10, nonQfEventGroup);
 
       const ids = pool.map(p => p.playerId);
       expect(new Set(ids).size).toBe(ids.length);
@@ -114,7 +134,7 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('p4', 'DEF', 'ARG', 7),
       ];
 
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 3);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'DEF', 3, nonQfEventGroup);
 
       expect(pool).toHaveLength(3);
       expect(pool.map(p => p.playerId)).toEqual(['p1', 'p2', 'p4']);
@@ -126,15 +146,25 @@ describe('WorldCupTeamsGameStrategy', () => {
         makeProjection('p2', 'GK', 'BRA', 8),
       ];
 
-      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 10);
+      const pool = await strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 10, nonQfEventGroup);
 
       expect(pool).toHaveLength(2);
     });
 
     it('returns empty array when no projections provided', async () => {
-      const pool = await strategy.determinePlayerPool([], {} as ITeam, 'GK', 5);
+      const pool = await strategy.determinePlayerPool([], {} as ITeam, 'GK', 5, nonQfEventGroup);
 
       expect(pool).toEqual([]);
+    });
+
+    it('throws when no eventGroup is provided', async () => {
+      const projections = [
+        makeProjection('arg1', 'GK', 'ARG', 10),
+      ];
+
+      await expect(
+        strategy.determinePlayerPool(projections, {} as ITeam, 'GK', 5),
+      ).rejects.toThrow('EventGroup is required for World Cup player pool determination');
     });
   });
 });

--- a/backend/src/world-cup/strategies/world-cup-teams-game.strategy.ts
+++ b/backend/src/world-cup/strategies/world-cup-teams-game.strategy.ts
@@ -1,3 +1,4 @@
+import { WORLD_CUP_STAGE_NAMES } from '@/world-cup/strategies/world-cup-event-sync.strategy';
 import { Injectable } from '@nestjs/common';
 import { EventGroup } from '@/events/entities/event-group.entity';
 import { IPlayerProjection } from '@/player-stats/entities/player-stats.entity';
@@ -29,6 +30,7 @@ export class WorldCupTeamsGameStrategy implements ITeamsGameStrategy {
     team: ITeam,
     position: string,
     _poolSize: number,
+    eventGroup?: EventGroup,
   ): Promise<IPlayerProjection[]> {
     const excluded = await this.getExcludedPlayerIds(team, position);
     const eligible = projections.filter(p => !excluded.includes(p.playerId));
@@ -50,20 +52,34 @@ export class WorldCupTeamsGameStrategy implements ITeamsGameStrategy {
         });
     }
 
+    if (!eventGroup) {
+      throw new Error('EventGroup is required for World Cup player pool determination');
+    }
+    const isQuarterfinals = this.isQuarterfinal(eventGroup);
+
     // Pool size is the per-position quota times the number of countries, plus the next top countries/2 players
     // unless it's for goalkeepers, where we don't add the extra players
-    const poolSize = Math.floor(countries.size * quota + (position === 'GK' ? 0 : countries.size / 2));
+    // For quarterfinals, we need to add extra keepers, otherwise the pool is too small to make offers
+    const extraFactor = (position === 'GK' && !isQuarterfinals) ? 0 : Math.floor(countries.size / 2);
+    const poolSize = Math.floor(countries.size * quota + extraFactor);
     pool.push(...sortedPlayerProjections
       .filter(p => !takenIds.has(p.playerId))
       .slice(0, poolSize - pool.length));
     return pool;
   }
 
-  getNumberOfCases(_eventGroup: EventGroup): number {
+  getNumberOfCases(eventGroup: EventGroup): number {
+    if (this.isQuarterfinal(eventGroup)) {
+      return 6;
+    }
     return 10;
   }
 
   normalizePlayerName(name: string): string {
     return name;
+  }
+
+  private isQuarterfinal(eventGroup: EventGroup): boolean {
+    return eventGroup.name.includes(WORLD_CUP_STAGE_NAMES['QF']);
   }
 }


### PR DESCRIPTION
Shrink cases to 6 for quartfinals
Detect quarterfinals in pool logic and make sure that we have enough GKs to make the offers needed